### PR TITLE
BugFix ShiroConfig.java

### DIFF
--- a/src/main/java/org/test/springbootshiro/ShiroConfig.java
+++ b/src/main/java/org/test/springbootshiro/ShiroConfig.java
@@ -30,7 +30,7 @@ public class ShiroConfig {
         bean.setSuccessUrl("/index");
         bean.setUnauthorizedUrl("/unauthorizedurl");
         Map<String, String> map = new LinkedHashMap<>();
-        map.put("/doLogin/", "anon");
+        map.put("/doLogin", "anon");
         map.put("/admin/*", "authc");
         bean.setFilterChainDefinitionMap(map);
         return  bean;


### PR DESCRIPTION
Bug: POST 请求`http://localhost:9090/doLogin` 时报错
`java.lang.IllegalArgumentException: There is no configured chain under the name/key [/doLogin]`

Fix: 修改 ShiroConfig 中[第33行](https://github.com/jweny/shiro-cve-2020-17523/blob/main/src/main/java/org/test/springbootshiro/ShiroConfig.java#L33) `map.put("/doLogin/", "anon");`为`map.put("/doLogin", "anon");`